### PR TITLE
Fixed the 'th' grammar mistake for previewing pieces

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -116,8 +116,13 @@ pub fn render(app: &mut App, frame: &mut Frame) {
                     Block::default()
                         .borders(borders)
                         .border_type(border_type)
-                        .title(format!("{}th", i)),
-                )
+                        .title(match i {
+                                    1 => {format!("{}st", i)}
+                                    2 => {format!("{}nd", i)}
+                                    3 => {format!("{}rd", i)}
+                                    _ => {format!("{}th", i)}
+                                })
+                        )
                 .paint(move |ctx| ctx.draw(&tetromino_to_preview)),
             ratatui::prelude::Rect::new(
                 next_preview_base_x,


### PR DESCRIPTION
The preview for the tetrominos had a grammar mistake that labelled every number with 'th'. For example it would state '1th' and '2th'. I have added a match case that checks for the special cases for 1, 2, and 3.